### PR TITLE
Adding localization to address, latitude and longitude (+ german translation)

### DIFF
--- a/admin/src/components/MapInput/index.js
+++ b/admin/src/components/MapInput/index.js
@@ -103,13 +103,29 @@ const MapField = ({
 
     <Grid>
       <GridItem padding={1} col={8} xs={12}>
-        <TextInput label="address" name="address" value={address} disabled />
+        <TextInput label={formatMessage({
+          id: getTranslation(
+            'map-field.fields.address'
+          ),
+          defaultMessage: 'address',
+        })} name="address" value={address} disabled
+      />
       </GridItem>
       <GridItem padding={1} col={2} xs={12}>
-        <TextInput label="longitude" name="longitude" value={longitude} disabled />
+        <TextInput label={formatMessage({
+          id: getTranslation(
+            'map-field.fields.longitude'
+          ),
+          defaultMessage: 'longitude',
+        })} name="longitude" value={longitude} disabled />
       </GridItem>
       <GridItem padding={1} col={2} xs={12}>
-        <TextInput label="latitude" name="latitude" value={latitude} disabled />
+        <TextInput label={formatMessage({
+          id: getTranslation(
+            'map-field.fields.latitude'
+          ),
+          defaultMessage: 'latitude',
+        })} name="latitude" value={latitude} disabled />
       </GridItem>
     </Grid>
   </Stack>

--- a/admin/src/components/MapInput/index.js
+++ b/admin/src/components/MapInput/index.js
@@ -4,6 +4,7 @@ import { Stack, Typography, TextInput, Grid, GridItem, Status } from '@strapi/de
 import Map, {FullscreenControl, GeolocateControl, Marker, NavigationControl} from 'react-map-gl';
 import GeocoderControl from './geocoder-control';
 import mbxGeocoding from '@mapbox/mapbox-sdk/services/geocoding'
+import getTranslation from '../../utils/getTrad';
 
 import 'mapbox-gl/dist/mapbox-gl.css';
 
@@ -105,7 +106,7 @@ const MapField = ({
       <GridItem padding={1} col={8} xs={12}>
         <TextInput label={formatMessage({
           id: getTranslation(
-            'map-field.fields.address'
+            'fields.address'
           ),
           defaultMessage: 'address',
         })} name="address" value={address} disabled
@@ -114,7 +115,7 @@ const MapField = ({
       <GridItem padding={1} col={2} xs={12}>
         <TextInput label={formatMessage({
           id: getTranslation(
-            'map-field.fields.longitude'
+            'fields.longitude'
           ),
           defaultMessage: 'longitude',
         })} name="longitude" value={longitude} disabled />
@@ -122,7 +123,7 @@ const MapField = ({
       <GridItem padding={1} col={2} xs={12}>
         <TextInput label={formatMessage({
           id: getTranslation(
-            'map-field.fields.latitude'
+            'fields.latitude'
           ),
           defaultMessage: 'latitude',
         })} name="latitude" value={latitude} disabled />

--- a/admin/src/translations/de.json
+++ b/admin/src/translations/de.json
@@ -1,0 +1,7 @@
+{
+  "map-field.label": "Karte",
+  "map-field.description": "Eine Kartenkomponente, basierend auf Mapbox",
+  "map-field.fields.address": "Addresse",
+  "map-field.fields.longitude": "Längengrad",
+  "map-field.fields.latitude": "Breitengrad"
+}

--- a/admin/src/translations/de.json
+++ b/admin/src/translations/de.json
@@ -1,7 +1,7 @@
 {
   "map-field.label": "Karte",
   "map-field.description": "Eine Kartenkomponente, basierend auf Mapbox",
-  "map-field.fields.address": "Addresse",
+  "map-field.fields.address": "Adresse",
   "map-field.fields.longitude": "Längengrad",
   "map-field.fields.latitude": "Breitengrad"
 }

--- a/admin/src/translations/en.json
+++ b/admin/src/translations/en.json
@@ -1,4 +1,7 @@
 {
   "map-field.label": "Map",
-  "map-field.description": "A map custom field using Mapbox"
+  "map-field.description": "A map custom field using Mapbox",
+  "map-field.fields.address": "address",
+  "map-field.fields.longitude": "longitude",
+  "map-field.fields.latitude": "latitude"
 }

--- a/admin/src/translations/fr.json
+++ b/admin/src/translations/fr.json
@@ -1,4 +1,7 @@
 {
   "map-field.label": "Carte",
-  "map-field.description": "Un champ carte utilisant Mapbox"
+  "map-field.description": "Un champ carte utilisant Mapbox",
+  "map-field.fields.address": "adresse",
+  "map-field.fields.longitude": "longitude",
+  "map-field.fields.latitude": "latitude"
 }


### PR DESCRIPTION
This PR adds support for localizing the address, latitude, and longitude fields at the bottom of the map in the Strapi admin dashboard. Also adds a translation definition for German.